### PR TITLE
Fix getNode return path

### DIFF
--- a/HierarchicalPathfinding/Source/Navigation.cpp
+++ b/HierarchicalPathfinding/Source/Navigation.cpp
@@ -1207,16 +1207,16 @@ void Navigation::setGraph()
 
 Graph::Node *Navigation::getNode(dtPolyRef ref, int l)
 {
-	if(l == level)
-		return &graphs[l].nodes[ref];
+        if (l == level)
+                return &graphs[l].nodes[ref];
 
-	Graph::Node *node = &graphs[l].nodes[ref];
-	
-	if(node->edges <= 0)
-		return NULL;
+        Graph::Node* node = &graphs[l].nodes[ref];
 
-	l++;
-	getNode(node->idParent,l);
+        if (node->numEdges <= 0)
+                return NULL;
+
+        l++;
+        return getNode(node->idParent, l);
 }
 
 void Navigation::checkPartition(int* part, const int numNodes, const int numParts)


### PR DESCRIPTION
## Summary
- fix missing return in `Navigation::getNode`
- ensure edge count check uses `numEdges`

## Testing
- `g++ -c HierarchicalPathfinding/Source/Navigation.cpp -IHierarchicalPathfinding/Include -IRecast/Include -IDetour/Include -IDetourCrowd/Include -IDetourTileCache/Include -IRecastDemo/Contrib/metis/include -o /tmp/navigation.o` *(fails: memset not declared)*

------
https://chatgpt.com/codex/tasks/task_e_68403ccaa11c8322b478464ccbcd3500