### PR TITLE
Fix typos in docs

### DIFF
--- a/Docs/Extern/Recast_api.txt
+++ b/Docs/Extern/Recast_api.txt
@@ -8,8 +8,8 @@
 Members in this module are used to create mesh data that is then
 used to create Detour navigation meshes.
 
-The are a large number of possible ways to building navigation mesh data.
-One of the simple piplines is as follows:
+There are a large number of possible ways to build navigation mesh data.
+One of the simple pipelines is as follows:
 
 -# Prepare the input triangle mesh.
 -# Build a #rcHeightfield.


### PR DESCRIPTION
## Summary
- fix grammar and spelling issues in Recast API documentation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68403e0855f883228be3cc3684642625